### PR TITLE
Update to Feliz 3.0 compatibility

### DIFF
--- a/src/Feliz.ChartJS/ChartJS.fs
+++ b/src/Feliz.ChartJS/ChartJS.fs
@@ -12,28 +12,28 @@ type ChartJS =
     /// Creates a new ChartJS component.
 
     static member inline line(props: ILineChartProp seq) =
-        Interop.reactApi.createElement (Interop.line, createObj !!props)
+        ReactLegacy.createElement (Interop.line, createObj !!props)
 
     static member inline bar(props: IBarChartProp seq) =
-        Interop.reactApi.createElement (Interop.bar, createObj !!props)
+        ReactLegacy.createElement (Interop.bar, createObj !!props)
 
     static member inline doughnut(props: IDoughnutChartProp seq) =
-        Interop.reactApi.createElement (Interop.doughnut, createObj !!props)
+        ReactLegacy.createElement (Interop.doughnut, createObj !!props)
 
     static member inline bubble(props: IBubbleChartProp seq) =
-        Interop.reactApi.createElement (Interop.bubble, createObj !!props)
+        ReactLegacy.createElement (Interop.bubble, createObj !!props)
 
     static member inline pie(props: IPieChartProp seq) =
-        Interop.reactApi.createElement (Interop.pie, createObj !!props)
+        ReactLegacy.createElement (Interop.pie, createObj !!props)
 
     static member inline radar(props: IRadarChartProp seq) =
-        Interop.reactApi.createElement (Interop.radar, createObj !!props)
+        ReactLegacy.createElement (Interop.radar, createObj !!props)
 
     static member inline polarArea(props: IPolarAreaChartProp seq) =
-        Interop.reactApi.createElement (Interop.polarArea, createObj !!props)
+        ReactLegacy.createElement (Interop.polarArea, createObj !!props)
 
     static member inline scatter(props: IScatterChartProp seq) =
-        Interop.reactApi.createElement (Interop.scatter, createObj !!props)
+        ReactLegacy.createElement (Interop.scatter, createObj !!props)
 
     static member inline option props : IOptionsProp = !!(createObj !!props)
 

--- a/src/Feliz.ChartJS/Interop.fs
+++ b/src/Feliz.ChartJS/Interop.fs
@@ -89,15 +89,15 @@ module Interop =
     // let hammerJS: obj = importAll "hammerjs"
     // let ZoomPlugin: obj = importAll "chartjs-plugin-zoom"
 
-    let chart: obj = import "Chart" "react-chartjs-2"
-    let line: obj = import "Line" "react-chartjs-2"
-    let doughnut: obj = import "Doughnut" "react-chartjs-2"
-    let bubble: obj = import "Bubble" "react-chartjs-2"
-    let bar: obj = import "Bar" "react-chartjs-2"
-    let pie: obj = import "Pie" "react-chartjs-2"
-    let radar: obj = import "Radar" "react-chartjs-2"
-    let polarArea: obj = import "PolarArea" "react-chartjs-2"
-    let scatter: obj = import "Scatter" "react-chartjs-2"
+    let chart: Feliz.ReactElement = import "Chart" "react-chartjs-2"
+    let line: Feliz.ReactElement = import "Line" "react-chartjs-2"
+    let doughnut: Feliz.ReactElement = import "Doughnut" "react-chartjs-2"
+    let bubble: Feliz.ReactElement = import "Bubble" "react-chartjs-2"
+    let bar: Feliz.ReactElement = import "Bar" "react-chartjs-2"
+    let pie: Feliz.ReactElement = import "Pie" "react-chartjs-2"
+    let radar: Feliz.ReactElement = import "Radar" "react-chartjs-2"
+    let polarArea: Feliz.ReactElement = import "PolarArea" "react-chartjs-2"
+    let scatter: Feliz.ReactElement = import "Scatter" "react-chartjs-2"
     type IEventOperations =
         abstract getDatasetAtEvent: ChartJS * MouseEvent -> InteractionItem []
         abstract getElementAtEvent: ChartJS * MouseEvent -> InteractionItem []


### PR DESCRIPTION
## Summary
- Replace `Interop.reactApi.createElement` with `ReactLegacy.createElement`
- Change chart component imports from `obj` to `ReactElement` type

This fixes compatibility with Feliz 3.0 which removed the `ReactApi` module.

## Breaking Changes
None - this is a backwards-compatible fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)